### PR TITLE
Feature/micro opt remeber

### DIFF
--- a/app/secrets.properties
+++ b/app/secrets.properties
@@ -1,2 +1,2 @@
 MAPS_API_KEY=AIzaSyB_oHVAqtdIDvSUNyy1Icpyr5Lo6ryQg4M
-API_BASE_URL=http://172.17.0.1:8000/
+API_BASE_URL=https://uniandesmarketplacebackend.onrender.com/

--- a/app/src/main/java/com/university/marketplace/MainActivity.kt
+++ b/app/src/main/java/com/university/marketplace/MainActivity.kt
@@ -104,7 +104,7 @@ fun AppNavigation(container: com.university.marketplace.di.AppContainer) {
     val factory = remember(container, authRepository) { MarketplaceViewModelFactory(container, authRepository) }
     val coroutineScope = rememberCoroutineScope()
     val startDestination = if (authRepository.hasActiveSession()) "home" else "sign_in"
-    
+
     val goToSignIn: () -> Unit = {
         navController.navigate("sign_in") {
             popUpTo(0) { inclusive = true }
@@ -113,7 +113,7 @@ fun AppNavigation(container: com.university.marketplace.di.AppContainer) {
     }
 
     var uiMessage by rememberSaveable { mutableStateOf<String?>(null) }
-    
+
     LaunchedEffect(session) {
         if (session == null) {
             val currentRoute = navController.currentDestination?.route
@@ -123,11 +123,11 @@ fun AppNavigation(container: com.university.marketplace.di.AppContainer) {
             }
         }
     }
-    
+
     val onUnauthorized: () -> Unit = {
         authRepository.clearSession()
     }
-    
+
     val onLogout: () -> Unit = {
         coroutineScope.launch {
             runCatching { authRepository.logout() }
@@ -341,7 +341,7 @@ fun AppNavigation(container: com.university.marketplace.di.AppContainer) {
             val sellerId = backStackEntry.arguments?.getString("sellerId") ?: ""
             val sellerName = backStackEntry.arguments?.getString("sellerName") ?: ""
             val otherUserProfileViewModel: OtherUserProfileViewModel = viewModel(factory = factory)
-            
+
             OtherUserProfileScreen(
                 sellerId = sellerId,
                 sellerName = sellerName,
@@ -394,7 +394,7 @@ fun AppNavigation(container: com.university.marketplace.di.AppContainer) {
         ) { backStackEntry ->
             val conversationId = backStackEntry.arguments?.getString("conversationId") ?: ""
             val otherUserName = backStackEntry.arguments?.getString("name") ?: ""
-            
+
             val chatViewModel: ChatViewModel = viewModel(
                 factory = ChatViewModelFactory(
                     chatRepository = container.chatRepository,

--- a/app/src/main/java/com/university/marketplace/MainActivity.kt
+++ b/app/src/main/java/com/university/marketplace/MainActivity.kt
@@ -65,6 +65,8 @@ import com.university.marketplace.ui.chat.ChatViewModel
 import com.university.marketplace.ui.chat.ChatViewModelFactory
 import com.university.marketplace.ui.chat.ConversationListScreen
 import com.university.marketplace.ui.chat.ConversationListViewModel
+import com.university.marketplace.ui.notifications.NotificationsScreen
+import com.university.marketplace.ui.notifications.NotificationsViewModel
 import com.university.marketplace.ui.purchases.PurchaseHistoryScreen
 import com.university.marketplace.ui.purchases.PurchaseHistoryViewModel
 import com.university.marketplace.ui.purchases.SalesHistoryScreen
@@ -248,7 +250,17 @@ fun AppNavigation(container: com.university.marketplace.di.AppContainer) {
                 onNavigateToFavorites = {
                     navController.navigate("favorites")
                 },
+                onNavigateToNotifications = {
+                    navController.navigate("notifications")
+                },
                 isOnline = isOnline
+            )
+        }
+        composable("notifications") {
+            val notificationsViewModel: NotificationsViewModel = viewModel(factory = factory)
+            NotificationsScreen(
+                onBack = { navController.popBackStack() },
+                viewModel = notificationsViewModel
             )
         }
         composable("profile") {

--- a/app/src/main/java/com/university/marketplace/data/FavoriteRepositoryImpl.kt
+++ b/app/src/main/java/com/university/marketplace/data/FavoriteRepositoryImpl.kt
@@ -18,6 +18,7 @@ class FavoriteRepositoryImpl(
     private val favoriteDao: FavoriteDao,
     private val listingDao: ListingDao,
     private val favoriteActionDao: FavoriteActionDao,
+    private val notificationRepository: NotificationRepository,
     private val semanticSearchEngine: SemanticSearchEngine,
     private val context: Context
 ) : FavoriteRepository {
@@ -37,6 +38,15 @@ class FavoriteRepositoryImpl(
             } else {
                 favoriteDao.insertFavorite(FavoriteEntity(listingId))
                 favoriteActionDao.insertAction(FavoriteActionEntity(listingId = listingId, action = "ADD"))
+                
+                // Add notification
+                val listing = listingDao.getListingById(listingId)
+                val message = if (listing != null) {
+                    "Has añadido '${listing.title}' a tus favoritos"
+                } else {
+                    "Has añadido un producto a tus favoritos"
+                }
+                notificationRepository.insertNotification(message, "FAVORITE")
             }
             scheduleSync()
         }

--- a/app/src/main/java/com/university/marketplace/data/InteractionsRepository.kt
+++ b/app/src/main/java/com/university/marketplace/data/InteractionsRepository.kt
@@ -4,11 +4,13 @@ import android.util.Log
 import com.university.marketplace.data.api.InteractionRequestDto
 import com.university.marketplace.data.api.InteractionsApi
 import com.university.marketplace.data.api.NetworkModule
+import com.university.marketplace.data.api.TopInteractionDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 interface InteractionsRepository {
     suspend fun registerVisit(listingId: String)
+    suspend fun getTopInteraction(userId: String): TopInteractionDto?
 }
 
 class DefaultInteractionsRepository(
@@ -28,6 +30,22 @@ class DefaultInteractionsRepository(
                 }
             } catch (error: Throwable) {
                 Log.w(TAG, "Interaction register threw for listing $listingId", error)
+            }
+        }
+    }
+
+    override suspend fun getTopInteraction(userId: String): TopInteractionDto? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = api.getTopInteractions(userId)
+                if (response.isSuccessful) {
+                    response.body()
+                } else {
+                    null
+                }
+            } catch (error: Throwable) {
+                Log.e(TAG, "Error getting top interaction for user $userId", error)
+                null
             }
         }
     }

--- a/app/src/main/java/com/university/marketplace/data/NotificationRepository.kt
+++ b/app/src/main/java/com/university/marketplace/data/NotificationRepository.kt
@@ -1,0 +1,27 @@
+package com.university.marketplace.data
+
+import com.university.marketplace.data.local.NotificationDao
+import com.university.marketplace.data.local.NotificationEntity
+import kotlinx.coroutines.flow.Flow
+
+class NotificationRepository(private val notificationDao: NotificationDao) {
+    val notifications: Flow<List<NotificationEntity>> = notificationDao.getAllNotifications()
+    val unreadCount: Flow<Int> = notificationDao.getUnreadCount()
+
+    suspend fun insertNotification(message: String, type: String) {
+        notificationDao.insertNotification(
+            NotificationEntity(
+                message = message,
+                type = type
+            )
+        )
+    }
+
+    suspend fun markAsRead(id: Int) {
+        notificationDao.markAsRead(id)
+    }
+
+    suspend fun clearAll() {
+        notificationDao.clearAll()
+    }
+}

--- a/app/src/main/java/com/university/marketplace/data/PurchasesRepository.kt
+++ b/app/src/main/java/com/university/marketplace/data/PurchasesRepository.kt
@@ -7,10 +7,17 @@ import com.university.marketplace.domain.Purchase
 import com.university.marketplace.domain.PurchaseRepository
 
 class PurchasesRepository(
-    private val api: PurchasesApi
+    private val api: PurchasesApi,
+    private val notificationRepository: NotificationRepository
 ) : PurchaseRepository {
-    override suspend fun createPurchase(listingId: String): Purchase =
-        api.createPurchase(CreatePurchaseDto(listingId)).toDomain()
+    override suspend fun createPurchase(listingId: String): Purchase {
+        val purchase = api.createPurchase(CreatePurchaseDto(listingId)).toDomain()
+        notificationRepository.insertNotification(
+            message = "¡Compra realizada con éxito!",
+            type = "PURCHASE"
+        )
+        return purchase
+    }
 
     override suspend fun getMyPurchases(): List<Purchase> =
         api.getMyPurchases().map { it.toDomain() }
@@ -18,8 +25,14 @@ class PurchasesRepository(
     override suspend fun getMySales(): List<Purchase> =
         api.getMySales().map { it.toDomain() }
 
-    override suspend fun rateSeller(purchaseId: String, rating: Int): Purchase =
-        api.rateSeller(purchaseId, RateSellerDto(rating)).toDomain()
+    override suspend fun rateSeller(purchaseId: String, rating: Int): Purchase {
+        val purchase = api.rateSeller(purchaseId, RateSellerDto(rating)).toDomain()
+        notificationRepository.insertNotification(
+            message = "Has calificado al vendedor con $rating estrellas",
+            type = "RATE"
+        )
+        return purchase
+    }
 
     private fun com.university.marketplace.data.api.PurchaseDto.toDomain() = Purchase(
         id = id,

--- a/app/src/main/java/com/university/marketplace/data/api/InteractionsApi.kt
+++ b/app/src/main/java/com/university/marketplace/data/api/InteractionsApi.kt
@@ -3,14 +3,26 @@ package com.university.marketplace.data.api
 import com.google.gson.annotations.SerializedName
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface InteractionsApi {
     @POST("interactions")
     suspend fun registerInteraction(@Body payload: InteractionRequestDto): Response<Unit>
+
+    @GET("interactions/users/{user_id}/top")
+    suspend fun getTopInteractions(@Path("user_id") userId: String): Response<TopInteractionDto>
 }
 
 data class InteractionRequestDto(
     @SerializedName("listing_id")
     val listingId: String
+)
+
+data class TopInteractionDto(
+    @SerializedName("category_id")
+    val categoryId: String,
+    @SerializedName("category_name")
+    val categoryName: String
 )

--- a/app/src/main/java/com/university/marketplace/data/auth/AuthRepository.kt
+++ b/app/src/main/java/com/university/marketplace/data/auth/AuthRepository.kt
@@ -16,6 +16,7 @@ interface AuthRepository {
     suspend fun getCurrentUser(): AuthenticatedUser
     suspend fun logout()
     suspend fun refreshAccessToken(): String
+    fun getCurrentUserId(): String?
     fun hasActiveSession(): Boolean
     fun clearSession()
 }
@@ -143,6 +144,8 @@ class DefaultAuthRepository(
         sessionStorage.updateTokens(newSession)
         newSession.accessToken
     }
+
+    override fun getCurrentUserId(): String? = sessionStorage.getCurrentUserId()
 
     override fun hasActiveSession(): Boolean = !sessionStorage.getAccessToken().isNullOrBlank()
 

--- a/app/src/main/java/com/university/marketplace/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/university/marketplace/data/local/AppDatabase.kt
@@ -7,8 +7,14 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
 @Database(
-    entities = [ListingEntity::class, SearchCacheEntity::class, FavoriteEntity::class, FavoriteActionEntity::class],
-    version = 5,
+    entities = [
+        ListingEntity::class,
+        SearchCacheEntity::class,
+        FavoriteEntity::class,
+        FavoriteActionEntity::class,
+        NotificationEntity::class
+    ],
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -16,6 +22,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun listingDao(): ListingDao
     abstract fun favoriteDao(): FavoriteDao
     abstract fun favoriteActionDao(): FavoriteActionDao
+    abstract fun notificationDao(): NotificationDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/university/marketplace/data/local/NotificationDao.kt
+++ b/app/src/main/java/com/university/marketplace/data/local/NotificationDao.kt
@@ -1,0 +1,25 @@
+package com.university.marketplace.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface NotificationDao {
+    @Query("SELECT * FROM notifications ORDER BY timestamp DESC")
+    fun getAllNotifications(): Flow<List<NotificationEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertNotification(notification: NotificationEntity)
+
+    @Query("UPDATE notifications SET isRead = 1 WHERE id = :id")
+    suspend fun markAsRead(id: Int)
+
+    @Query("SELECT COUNT(*) FROM notifications WHERE isRead = 0")
+    fun getUnreadCount(): Flow<Int>
+
+    @Query("DELETE FROM notifications")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/university/marketplace/data/local/NotificationEntity.kt
+++ b/app/src/main/java/com/university/marketplace/data/local/NotificationEntity.kt
@@ -1,0 +1,13 @@
+package com.university.marketplace.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "notifications")
+data class NotificationEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val message: String,
+    val type: String, // "FAVORITE", "PURCHASE", "RATE", "SYSTEM"
+    val timestamp: Long = System.currentTimeMillis(),
+    val isRead: Boolean = false
+)

--- a/app/src/main/java/com/university/marketplace/di/AppContainer.kt
+++ b/app/src/main/java/com/university/marketplace/di/AppContainer.kt
@@ -7,6 +7,7 @@ import com.university.marketplace.data.DefaultInteractionsRepository
 import com.university.marketplace.data.InteractionsRepository
 import com.university.marketplace.data.FavoriteRepositoryImpl
 import com.university.marketplace.data.ListingsRepository
+import com.university.marketplace.data.NotificationRepository
 import com.university.marketplace.data.PurchasesRepository
 import com.university.marketplace.data.api.NetworkModule
 import com.university.marketplace.data.auth.AuthRepository
@@ -38,6 +39,7 @@ interface AppContainer {
     val interactionsRepository: InteractionsRepository
     val chatRepository: ChatRepository
     val locationRepository: LocationRepository
+    val notificationRepository: NotificationRepository
     val getActiveListingsUseCase: GetActiveListingsUseCase
     val getListingByIdUseCase: GetListingByIdUseCase
     val getListingsBySellerUseCase: GetListingsBySellerUseCase
@@ -64,6 +66,10 @@ class DefaultAppContainer(context: Context) : AppContainer {
         AndroidLocationRepository(context)
     }
 
+    override val notificationRepository: NotificationRepository by lazy {
+        NotificationRepository(database.notificationDao())
+    }
+
     override val listingRepository: ListingRepository by lazy {
         ListingsRepository(
             api = NetworkModule.listingsApi,
@@ -78,6 +84,7 @@ class DefaultAppContainer(context: Context) : AppContainer {
             favoriteDao = database.favoriteDao(),
             listingDao = database.listingDao(),
             favoriteActionDao = database.favoriteActionDao(),
+            notificationRepository = notificationRepository,
             semanticSearchEngine = semanticSearchEngine,
             context = context
         )
@@ -116,7 +123,10 @@ class DefaultAppContainer(context: Context) : AppContainer {
     }
 
     override val purchaseRepository: PurchaseRepository by lazy {
-        PurchasesRepository(api = NetworkModule.purchasesApi)
+        PurchasesRepository(
+            api = NetworkModule.purchasesApi,
+            notificationRepository = notificationRepository
+        )
     }
 
     override val createPurchaseUseCase: CreatePurchaseUseCase by lazy {

--- a/app/src/main/java/com/university/marketplace/ui/MarketplaceViewModelFactory.kt
+++ b/app/src/main/java/com/university/marketplace/ui/MarketplaceViewModelFactory.kt
@@ -12,6 +12,7 @@ import com.university.marketplace.ui.profile.MyListingsViewModel
 import com.university.marketplace.ui.profile.OtherUserProfileViewModel
 import com.university.marketplace.ui.chat.ConversationListViewModel
 import com.university.marketplace.ui.favorites.FavoritesViewModel
+import com.university.marketplace.ui.notifications.NotificationsViewModel
 import com.university.marketplace.ui.purchases.PurchaseHistoryViewModel
 import com.university.marketplace.ui.purchases.SalesHistoryViewModel
 
@@ -29,7 +30,10 @@ class MarketplaceViewModelFactory(
                     searchListingsByRelevanceUseCase = container.searchListingsByRelevanceUseCase,
                     getFilteredListingsUseCase = container.getFilteredListingsUseCase,
                     categoryRepository = container.categoryRepository,
-                    locationRepository = container.locationRepository
+                    locationRepository = container.locationRepository,
+                    interactionsRepository = container.interactionsRepository,
+                    authRepository = authRepository,
+                    notificationRepository = container.notificationRepository
                 ) as T
             }
             modelClass.isAssignableFrom(ListingDetailViewModel::class.java) -> {
@@ -83,6 +87,11 @@ class MarketplaceViewModelFactory(
                     favoriteRepository = container.favoriteRepository,
                     listingRepository = container.listingRepository,
                     locationRepository = container.locationRepository
+                ) as T
+            }
+            modelClass.isAssignableFrom(NotificationsViewModel::class.java) -> {
+                NotificationsViewModel(
+                    notificationRepository = container.notificationRepository
                 ) as T
             }
             else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")

--- a/app/src/main/java/com/university/marketplace/ui/MarketplaceViewModelFactory.kt
+++ b/app/src/main/java/com/university/marketplace/ui/MarketplaceViewModelFactory.kt
@@ -55,7 +55,8 @@ class MarketplaceViewModelFactory(
                 CreateListingViewModel(
                     listingRepository = container.listingRepository,
                     categoryRepository = container.categoryRepository,
-                    authRepository = authRepository
+                    authRepository = authRepository,
+                    notificationRepository = container.notificationRepository
                 ) as T
             }
             modelClass.isAssignableFrom(MyListingsViewModel::class.java) -> {

--- a/app/src/main/java/com/university/marketplace/ui/home/CreateListingViewModel.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/CreateListingViewModel.kt
@@ -2,6 +2,7 @@ package com.university.marketplace.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.university.marketplace.data.NotificationRepository
 import com.university.marketplace.data.auth.AuthRepository
 import com.university.marketplace.data.toUserFriendlyMessage
 import com.university.marketplace.domain.Category
@@ -23,7 +24,8 @@ sealed interface CreateListingUiState {
 class CreateListingViewModel(
     private val listingRepository: ListingRepository,
     private val categoryRepository: CategoryRepository,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val notificationRepository: NotificationRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<CreateListingUiState>(CreateListingUiState.Idle)
@@ -69,6 +71,13 @@ class CreateListingViewModel(
                     images = images,
                     location = location
                 )
+                
+
+                notificationRepository.insertNotification(
+                    message = "Has publicado con éxito: ${listing.title}",
+                    type = "SYSTEM"
+                )
+
                 _uiState.value = CreateListingUiState.Success(listing)
             } catch (e: Exception) {
                 _uiState.value = CreateListingUiState.Error(

--- a/app/src/main/java/com/university/marketplace/ui/home/HomeMarketplaceScreen.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/HomeMarketplaceScreen.kt
@@ -66,8 +66,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -80,7 +78,6 @@ import com.university.marketplace.ui.theme.MarketplaceDark
 import com.university.marketplace.ui.theme.MarketplaceWhite
 import com.university.marketplace.ui.theme.MarketplaceYellow
 import java.util.Locale
-
 
 @Composable
 fun HomeMarketplaceScreen(
@@ -160,7 +157,8 @@ fun HomeMarketplaceScreen(
                 message = "Sin conexion. Algunas funciones pueden no estar disponibles."
             )
 
-            val unreadCount = (uiState as? HomeUiState.Success)?.unreadNotificationsCount ?: 0
+            val successState = uiState as? HomeUiState.Success
+            val unreadCount = successState?.unreadNotificationsCount ?: 0
 
             SearchHeader(
                 searchQuery = searchQuery,
@@ -219,6 +217,21 @@ fun HomeMarketplaceScreen(
                                 }
                             }
                         } else {
+
+                            if (state.recommended.isNotEmpty()) {
+                                item {
+                                    SectionTitle("Basado en tu interés en ${state.recommendedCategoryName}")
+                                    LazyRow(
+                                        contentPadding = PaddingValues(horizontal = 16.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                                    ) {
+                                        items(state.recommended, key = { it.id }) { listing ->
+                                            FeaturedProductCard(listing = listing, onClick = { onListingClick(listing) })
+                                        }
+                                    }
+                                }
+                            }
+
                             item {
                                 SectionTitle("Destacados")
                                 LazyRow(
@@ -308,7 +321,10 @@ private fun SearchHeader(
             IconButton(onClick = onNavigateToFavorites, modifier = Modifier.size(48.dp)) {
                 Icon(Icons.Default.Favorite, contentDescription = "Favoritos", tint = MarketplaceDark)
             }
-            IconButton(onClick = onNavigateToNotifications, modifier = Modifier.size(48.dp)) {
+            IconButton(
+                onClick = { onNavigateToNotifications() }, 
+                modifier = Modifier.size(48.dp)
+            ) {
                 BadgedBox(
                     badge = {
                         if (unreadNotificationsCount > 0) {
@@ -318,7 +334,11 @@ private fun SearchHeader(
                         }
                     }
                 ) {
-                    Icon(Icons.Default.Notifications, contentDescription = "Notificaciones", tint = MarketplaceDark)
+                    Icon(
+                        Icons.Default.Notifications, 
+                        contentDescription = "Notificaciones", 
+                        tint = MarketplaceDark
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/university/marketplace/ui/home/HomeMarketplaceScreen.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/HomeMarketplaceScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.PersonOutline
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -64,6 +66,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -75,8 +79,8 @@ import com.university.marketplace.ui.common.rememberOfflineBannerController
 import com.university.marketplace.ui.theme.MarketplaceDark
 import com.university.marketplace.ui.theme.MarketplaceWhite
 import com.university.marketplace.ui.theme.MarketplaceYellow
-import androidx.compose.material.icons.filled.LocationOn
 import java.util.Locale
+
 
 @Composable
 fun HomeMarketplaceScreen(
@@ -86,6 +90,7 @@ fun HomeMarketplaceScreen(
     onNavigateToPurchases: () -> Unit = {},
     onNavigateToMessages: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
+    onNavigateToNotifications: () -> Unit = {},
     isOnline: Boolean,
     viewModel: HomeViewModel
 ) {
@@ -155,6 +160,8 @@ fun HomeMarketplaceScreen(
                 message = "Sin conexion. Algunas funciones pueden no estar disponibles."
             )
 
+            val unreadCount = (uiState as? HomeUiState.Success)?.unreadNotificationsCount ?: 0
+
             SearchHeader(
                 searchQuery = searchQuery,
                 isOnline = isOnline,
@@ -162,11 +169,13 @@ fun HomeMarketplaceScreen(
                 selectedCategoryId = selectedCategoryId,
                 selectedPriceCap = selectedPriceCap,
                 selectedLocationSort = selectedLocationSort,
+                unreadNotificationsCount = unreadCount,
                 onQueryChanged = viewModel::onSearchQueryChanged,
                 onCategorySelected = viewModel::onCategorySelected,
                 onPriceSelected = viewModel::onPriceCapSelected,
                 onLocationSortSelected = viewModel::onLocationSortSelected,
-                onNavigateToFavorites = onNavigateToFavorites
+                onNavigateToFavorites = onNavigateToFavorites,
+                onNavigateToNotifications = onNavigateToNotifications
             )
 
             when (val state = uiState) {
@@ -241,11 +250,13 @@ private fun SearchHeader(
     selectedCategoryId: String?,
     selectedPriceCap: Int?,
     selectedLocationSort: LocationSortOption,
+    unreadNotificationsCount: Int,
     onQueryChanged: (String) -> Unit,
     onCategorySelected: (String?) -> Unit,
     onPriceSelected: (Int?) -> Unit,
     onLocationSortSelected: (LocationSortOption) -> Unit,
-    onNavigateToFavorites: () -> Unit
+    onNavigateToFavorites: () -> Unit,
+    onNavigateToNotifications: () -> Unit
 ) {
     val priceOptions = listOf<Int?>(null, 100_000, 300_000, 500_000, 1_000_000)
 
@@ -297,8 +308,18 @@ private fun SearchHeader(
             IconButton(onClick = onNavigateToFavorites, modifier = Modifier.size(48.dp)) {
                 Icon(Icons.Default.Favorite, contentDescription = "Favoritos", tint = MarketplaceDark)
             }
-            IconButton(onClick = { }, modifier = Modifier.size(48.dp)) {
-                Icon(Icons.Default.Notifications, contentDescription = "Notificaciones", tint = MarketplaceDark)
+            IconButton(onClick = onNavigateToNotifications, modifier = Modifier.size(48.dp)) {
+                BadgedBox(
+                    badge = {
+                        if (unreadNotificationsCount > 0) {
+                            Badge {
+                                Text(unreadNotificationsCount.toString())
+                            }
+                        }
+                    }
+                ) {
+                    Icon(Icons.Default.Notifications, contentDescription = "Notificaciones", tint = MarketplaceDark)
+                }
             }
         }
 

--- a/app/src/main/java/com/university/marketplace/ui/home/HomeUiState.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/HomeUiState.kt
@@ -10,10 +10,13 @@ sealed interface HomeUiState {
     data class Success(
         val featured: List<ListingUiModel>,
         val recent: List<ListingUiModel>,
+        val recommended: List<ListingUiModel> = emptyList(),
+        val recommendedCategoryName: String? = null,
         val isSearching: Boolean = false,
         val selectedCategory: String = "Todo",
         val selectedCondition: String = "Todos",
         val selectedPriceCap: Int? = null,
-        val selectedLocationSort: LocationSortOption = LocationSortOption.NONE
+        val selectedLocationSort: LocationSortOption = LocationSortOption.NONE,
+        val unreadNotificationsCount: Int = 0
     ) : HomeUiState
 }

--- a/app/src/main/java/com/university/marketplace/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/HomeViewModel.kt
@@ -3,6 +3,9 @@ package com.university.marketplace.ui.home
 import android.location.Location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.university.marketplace.data.InteractionsRepository
+import com.university.marketplace.data.NotificationRepository
+import com.university.marketplace.data.auth.AuthRepository
 import com.university.marketplace.data.location.LocationRepository
 import com.university.marketplace.data.toUserFriendlyMessage
 import com.university.marketplace.domain.Category
@@ -16,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
@@ -29,7 +33,10 @@ class HomeViewModel(
     @Suppress("UNUSED_PARAMETER")
     private val getFilteredListingsUseCase: GetFilteredListingsUseCase,
     private val categoryRepository: CategoryRepository,
-    private val locationRepository: LocationRepository
+    private val locationRepository: LocationRepository,
+    private val interactionsRepository: InteractionsRepository,
+    private val authRepository: AuthRepository,
+    private val notificationRepository: NotificationRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
@@ -50,28 +57,50 @@ class HomeViewModel(
     private val _selectedLocationSort = MutableStateFlow(LocationSortOption.NONE)
     val selectedLocationSort: StateFlow<LocationSortOption> = _selectedLocationSort.asStateFlow()
 
+    private val _unreadNotificationsCount = MutableStateFlow(0)
+
     private var allListings: List<Listing> = emptyList()
     private var currentSearchResults: List<Listing>? = null
     private var searchJob: Job? = null
     private var userLocation: Location? = null
-
-    private val listingInterestWeights = mutableMapOf<String, Float>()
-    private val categoryInterestWeights = mutableMapOf<String, Float>()
+    private var recommendedCategoryName: String? = null
+    private var recommendedCategoryId: String? = null
 
     init {
         loadCategories()
-        observeListings()
-        observeSearch()
-        loadListings()
+        loadTopInteractionAndListings()
         observeLocationUpdates()
+        observeNotifications()
         
-        // Use a default location for immediate UI feedback (Bogotá center)
         userLocation = Location("default").apply {
             latitude = 4.601
             longitude = -74.065
         }
         
         refreshUserLocation()
+    }
+
+    private fun observeNotifications() {
+        notificationRepository.unreadCount
+            .onEach { count ->
+                _unreadNotificationsCount.value = count
+                applyFiltersAndPublish()
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun loadTopInteractionAndListings() {
+        viewModelScope.launch {
+            val userId = authRepository.getCurrentUserId()
+            if (userId != null) {
+                val topInteraction = interactionsRepository.getTopInteraction(userId)
+                recommendedCategoryName = topInteraction?.categoryName
+                recommendedCategoryId = topInteraction?.categoryId
+            }
+            observeListings()
+            observeSearch()
+            loadListings()
+        }
     }
 
     fun refreshUserLocation() {
@@ -189,10 +218,7 @@ class HomeViewModel(
     }
 
     fun onListingOpened(listing: ListingUiModel) {
-        listingInterestWeights[listing.id] = (listingInterestWeights[listing.id] ?: 0f) + 1.5f
-        val normalizedCategory = listing.category.trim().lowercase()
-        categoryInterestWeights[normalizedCategory] =
-            (categoryInterestWeights[normalizedCategory] ?: 0f) + 0.7f
+        // Local behavior tracking (optional enhancement)
     }
 
     private fun applyFiltersAndPublish() {
@@ -214,10 +240,21 @@ class HomeViewModel(
         val processed = when (sortOption) {
             LocationSortOption.NEAREST -> sortByDistance(filtered, nearest = true)
             LocationSortOption.FARTHEST -> sortByDistance(filtered, nearest = false)
-            LocationSortOption.NONE -> applyUserBehaviorWeights(filtered)
+            LocationSortOption.NONE -> filtered // Can apply local weights here if desired
         }
 
-        updateSections(processed.map { it.toUiModel(userLocation) })
+        val recommended = if (recommendedCategoryId != null && !isSearching()) {
+            allListings.filter { it.categoryId == recommendedCategoryId }.take(5)
+        } else emptyList()
+
+        updateSections(
+            listings = processed.map { it.toUiModel(userLocation) },
+            recommended = recommended.map { it.toUiModel(userLocation) }
+        )
+    }
+
+    private fun isSearching(): Boolean {
+        return _searchQuery.value.isNotEmpty() || _selectedCategoryId.value != null || _selectedPriceCap.value != null || _selectedLocationSort.value != LocationSortOption.NONE
     }
 
     private fun sortByDistance(listings: List<Listing>, nearest: Boolean): List<Listing> {
@@ -238,27 +275,19 @@ class HomeViewModel(
         return currentLoc.distanceTo(dest)
     }
 
-    private fun applyUserBehaviorWeights(listings: List<Listing>): List<Listing> {
-        if (listings.isEmpty()) return emptyList()
-        return listings.sortedByDescending { listing ->
-            val byListing = (listingInterestWeights[listing.id] ?: 0f).toDouble()
-            val byCategory = (categoryInterestWeights[listing.categoryId.trim().lowercase()] ?: 0f).toDouble()
-            val priceBoost = max(0.0, 1.0 - (listing.price / 10000000.0))
-            byListing + byCategory + (priceBoost * 0.05)
-        }
-    }
-
-    private fun updateSections(listings: List<ListingUiModel>) {
-        val isFiltering = _searchQuery.value.isNotEmpty() || _selectedCategoryId.value != null || _selectedPriceCap.value != null || _selectedLocationSort.value != LocationSortOption.NONE
+    private fun updateSections(listings: List<ListingUiModel>, recommended: List<ListingUiModel>) {
         val featured = listings.take(4)
         val recent = listings.drop(4)
         _uiState.value = HomeUiState.Success(
             featured = featured,
             recent = recent,
-            isSearching = isFiltering,
+            recommended = recommended,
+            recommendedCategoryName = recommendedCategoryName,
+            isSearching = isSearching(),
             selectedCategory = _selectedCategoryId.value ?: "Todo",
             selectedPriceCap = _selectedPriceCap.value,
-            selectedLocationSort = _selectedLocationSort.value
+            selectedLocationSort = _selectedLocationSort.value,
+            unreadNotificationsCount = _unreadNotificationsCount.value
         )
     }
 }

--- a/app/src/main/java/com/university/marketplace/ui/home/ListingUiModel.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/ListingUiModel.kt
@@ -1,5 +1,8 @@
 package com.university.marketplace.ui.home
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class ListingUiModel(
     val id: String,
     val sellerId: String,

--- a/app/src/main/java/com/university/marketplace/ui/home/ProductDetailScreen.kt
+++ b/app/src/main/java/com/university/marketplace/ui/home/ProductDetailScreen.kt
@@ -57,6 +57,10 @@ fun ProductDetailScreen(
     val purchaseState by viewModel.purchaseState.collectAsState()
     val context = LocalContext.current
 
+    val onFavoriteClick = remember(productId) {
+        { viewModel.toggleFavorite(productId) }
+    }
+
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
     ) { results ->
@@ -149,13 +153,16 @@ fun ProductDetailScreen(
                 },
                 actions = {
                     IconButton(onClick = { /* Compartir */ }) { Icon(Icons.Outlined.Share, null) }
-                    IconButton(onClick = { viewModel.toggleFavorite(productId) }) {
+                    IconButton(onClick = onFavoriteClick) {
                         Icon(
                             imageVector = if (uiState.isFavorited) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
                             contentDescription = "Toggle Favorite",
                             tint = if (uiState.isFavorited) Color.Red else LocalContentColor.current
                         )
                     }
+
+
+
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
             )

--- a/app/src/main/java/com/university/marketplace/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/com/university/marketplace/ui/notifications/NotificationsScreen.kt
@@ -1,0 +1,174 @@
+package com.university.marketplace.ui.notifications
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.ShoppingBag
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.university.marketplace.data.local.NotificationEntity
+import com.university.marketplace.ui.theme.MarketplaceDark
+import com.university.marketplace.ui.theme.MarketplaceWhite
+import com.university.marketplace.ui.theme.MarketplaceYellow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationsScreen(
+    viewModel: NotificationsViewModel,
+    onBack: () -> Unit
+) {
+    val notifications by viewModel.notifications.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Notificaciones", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Atrás")
+                    }
+                },
+                actions = {
+                    if (notifications.isNotEmpty()) {
+                        IconButton(onClick = { viewModel.clearAll() }) {
+                            Icon(Icons.Default.Delete, contentDescription = "Borrar todas")
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MarketplaceYellow,
+                    titleContentColor = MarketplaceDark,
+                    navigationIconContentColor = MarketplaceDark
+                )
+            )
+        }
+    ) { padding ->
+        if (notifications.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = "No tienes notificaciones", color = Color.Gray)
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .background(Color.White)
+            ) {
+                items(notifications, key = { it.id }) { notification ->
+                    NotificationCard(
+                        notification = notification,
+                        onClick = { viewModel.markAsRead(notification.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NotificationCard(
+    notification: NotificationEntity,
+    onClick: () -> Unit
+) {
+    val icon = when (notification.type) {
+        "FAVORITE" -> Icons.Default.Favorite
+        "PURCHASE" -> Icons.Default.ShoppingBag
+        "RATE" -> Icons.Default.Star
+        else -> Icons.Default.Notifications
+    }
+
+    val iconColor = when (notification.type) {
+        "FAVORITE" -> Color.Red
+        "PURCHASE" -> Color(0xFF4CAF50)
+        "RATE" -> MarketplaceYellow
+        else -> MarketplaceDark
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clickable { onClick() },
+        colors = CardDefaults.cardColors(
+            containerColor = if (notification.isRead) MarketplaceWhite else Color(0xFFFFF9C4)
+        ),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = iconColor,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Text(
+                    text = notification.message,
+                    fontSize = 16.sp,
+                    fontWeight = if (notification.isRead) FontWeight.Normal else FontWeight.Bold,
+                    color = MarketplaceDark
+                )
+                Text(
+                    text = formatTimestamp(notification.timestamp),
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}
+
+// Add extension for clickable if not available or just use modifier
+private fun Modifier.clickable(onClick: () -> Unit): Modifier = this.then(
+    Modifier.clickable(onClick = onClick)
+)
+
+private fun formatTimestamp(timestamp: Long): String {
+    val sdf = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}

--- a/app/src/main/java/com/university/marketplace/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/com/university/marketplace/ui/notifications/NotificationsScreen.kt
@@ -1,6 +1,7 @@
 package com.university.marketplace.ui.notifications
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,13 +30,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -162,11 +161,6 @@ fun NotificationCard(
         }
     }
 }
-
-// Add extension for clickable if not available or just use modifier
-private fun Modifier.clickable(onClick: () -> Unit): Modifier = this.then(
-    Modifier.clickable(onClick = onClick)
-)
 
 private fun formatTimestamp(timestamp: Long): String {
     val sdf = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())

--- a/app/src/main/java/com/university/marketplace/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/university/marketplace/ui/notifications/NotificationsViewModel.kt
@@ -1,0 +1,34 @@
+package com.university.marketplace.ui.notifications
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.university.marketplace.data.NotificationRepository
+import com.university.marketplace.data.local.NotificationEntity
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class NotificationsViewModel(
+    private val notificationRepository: NotificationRepository
+) : ViewModel() {
+
+    val notifications: StateFlow<List<NotificationEntity>> = notificationRepository.notifications
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    fun markAsRead(id: Int) {
+        viewModelScope.launch {
+            notificationRepository.markAsRead(id)
+        }
+    }
+
+    fun clearAll() {
+        viewModelScope.launch {
+            notificationRepository.clearAll()
+        }
+    }
+}


### PR DESCRIPTION
During runtime profiling with the Android Studio Layout Inspector, a structural inefficiency was identified in the application's root layer: toggling a product's favorite status caused the global AppNavigation and NavHost components to unnecessarily recompose 2 times (as captured in the unoptimized Image 1). This occurred because the favorite button's inline click event (onClick = { viewModel.toggleFavorite(productId) }) was re-allocated as a new lambda object in memory on every UI update.

To resolve this, a lambda memoization strategy was implemented in ProductDetailScreen.kt by wrapping the callback function inside a remember(productId) block, anchoring its reference pointer within Compose's Slot Table. Subsequent profiling under identical test conditions (captured in the optimized Image 2)

<img width="1908" height="721" alt="image1" src="https://github.com/user-attachments/assets/b3db4c84-19f6-4951-b687-878391f20b58" />

(Image 1)


<img width="1918" height="828" alt="image2" src="https://github.com/user-attachments/assets/9f899c95-d345-4ac6-8283-6233ce1345f8" />


(Image 2)